### PR TITLE
Add error handling to Get-Content for tagName

### DIFF
--- a/source/EgsFreeGamesChecker.psm1
+++ b/source/EgsFreeGamesChecker.psm1
@@ -121,7 +121,7 @@ function CheckGame ($gameToCheck, $CsvList)
 	
 	$ReturnValue = ""
 	
-    $tagName = Get-Content $tagFilePath
+    $tagName = Get-Content $tagFilePath -ErrorAction SilentlyContinue
 	if ($tagName -eq "")
     {
 		UpdateTagName


### PR DESCRIPTION
Adds `-ErrorAction SilentlyContinue` to `Get-Content $tagFilePath`

I had an error that the file didn't exist on my first run.

I might also not have read the manual correctly too :|